### PR TITLE
[REFACTOR/#123] toast 로직 export 제거 및 UI 전용으로 정리

### DIFF
--- a/.changeset/shaggy-rivers-hunt.md
+++ b/.changeset/shaggy-rivers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@causw/core': patch
+---
+
+toast 로직 export 제거

--- a/packages/core/src/components/Toast/index.ts
+++ b/packages/core/src/components/Toast/index.ts
@@ -1,5 +1,3 @@
 export { Toast, ToastViewport, ToastProvider } from './Toast';
 export type { ToastProps, ToastViewportProps } from './Toast';
 export { type ToastVariants } from './Toast.styles';
-export { toast } from './toastStore';
-export { Toaster } from './Toaster';


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #123 

## ✨ Summary

서비스 레포에서 toast 로직을 직접 구현하도록 구조를 정리하기 위해, 디자인 시스템에서 toast 상태 관리 관련 export를 제거했습니다.

## 📚 Details of Changes

- `Toaster` 컴포넌트 export 제거
- `toast` 로직 export 제거

## 🎯 Key points to review

- 

## 🧪 Test & Verification
- [x] Storybook UI 확인
- [x] Storybook test (pnpm test-storybook) 완료

## 📎 Additional Notes

<img width="741" height="105" alt="스크린샷 2026-02-22 135324" src="https://github.com/user-attachments/assets/8edfc716-b01d-44f6-9378-62d4e9ddad28" />

- 기존에 디자인 시스템에서 로직 관련 import가 가능했던 구조로 인해 서비스 레포에서 toast 사용시 혼란이 발생할 수 있어 제거

UI와 로직을 분리함으로써 hydration 이슈는 서비스 레포(v3)에서 해결 (https://github.com/CAUCSE/CAUSW-frontend-v3/pull/72)