### PR TITLE
[FIX/#144] vstack hstack에서 as props 활용한 태그 변환에 대한 타입추론 되지 않는 문제 핸들링

### DIFF
--- a/.changeset/honest-times-ask.md
+++ b/.changeset/honest-times-ask.md
@@ -1,0 +1,6 @@
+---
+'@causw/core': patch
+'@causw/design-system': patch
+---
+
+vstack, hstack 타입 추론 제대로 되지 않는 이슈 핸들링

--- a/packages/core/src/components/HStack/HStack.tsx
+++ b/packages/core/src/components/HStack/HStack.tsx
@@ -1,15 +1,14 @@
 import React, { type ElementType } from 'react';
 import { Stack, type StackProps } from '../Stack';
 
-export type HStackProps<E extends ElementType = 'div'> = Omit<
-  StackProps<E>,
-  'direction'
->;
+export type HStackProps<E extends ElementType = 'div'> = StackProps<E> & {
+  direction?: never;
+};
 
 export const HStack = <E extends ElementType = 'div'>({
   ...props
 }: HStackProps<E>) => {
-  return <Stack<E> direction="horizontal" {...(props as StackProps<E>)} />;
+  return <Stack {...props} direction="horizontal" />;
 };
 
 HStack.displayName = 'HStack';

--- a/packages/core/src/components/VStack/VStack.tsx
+++ b/packages/core/src/components/VStack/VStack.tsx
@@ -1,15 +1,14 @@
 import React, { type ElementType } from 'react';
 import { Stack, type StackProps } from '../Stack';
 
-export type VStackProps<E extends ElementType = 'div'> = Omit<
-  StackProps<E>,
-  'direction'
->;
+export type VStackProps<E extends ElementType = 'div'> = StackProps<E> & {
+  direction?: never;
+};
 
 export const VStack = <E extends ElementType = 'div'>({
   ...props
 }: VStackProps<E>) => {
-  return <Stack<E> direction="vertical" {...(props as StackProps<E>)} />;
+  return <Stack {...props} direction="vertical" />;
 };
 
 VStack.displayName = 'VStack';


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
> 관련 이슈를 태그해주세요

- Closes #144 


## ✨ Summary
> 이번 PR에서 어떤 변화가 있었는지 한 줄 요약해주세요.

- vstack hstack에서 as props 활용한 태그 변환에 대한 타입추론 되지 않는 문제 핸들링


## 📚 Details of Changes
> 주요 변경 사항을 bullet로 정리해주세요.

- vstack hstack에서 as props 활용한 태그 변환에 대한 타입추론 되지 않는 문제 핸들링


## 🎯 Key points to review
> 이 부분들을 중점적으로 리뷰해주세요.

- 


## 🧪 Test & Verification
- [ ] Storybook UI 확인
- [ ] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes
-
