### PR TITLE
[REFACTOR/#156] bottomsheet 스와이프 제스처 비활성화 옵션 추가

### DIFF
--- a/.changeset/proud-crabs-create.md
+++ b/.changeset/proud-crabs-create.md
@@ -1,0 +1,5 @@
+---
+'@causw/core': patch
+---
+
+BottomSheet 스와이프 제스처 비활성화 옵션 추가

--- a/packages/core/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -182,3 +182,39 @@ export const LongContent: Story = {
     </BottomSheet>
   ),
 };
+
+export const DisableSwipeGesture: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+**제스처 비활성화(Disable Swipe Gesture)** 예제입니다.
+
+- \`dismissible={false}\`를 통해 사용자의 스와이프(드래그) 제스처로 BottomSheet를 닫을 수 없도록 합니다.
+- 의도하지 않은 닫힘을 방지하거나, 특정 플로우를 강제해야 하는 경우에 유용합니다.
+- 이 경우 시트를 닫기 위해서는 버튼 클릭 등 명시적인 액션이 필요합니다.
+        `,
+      },
+    },
+  },
+  render: (args) => (
+    <BottomSheet {...args} dismissible={false}>
+      <BottomSheet.Trigger asChild>
+        <button className="cursor-pointer rounded-sm bg-blue-500 px-4 py-2 text-sm text-white transition-colors hover:bg-blue-600 hover:text-gray-200">
+          Open
+        </button>
+      </BottomSheet.Trigger>
+
+      <BottomSheet.Content>
+        <BottomSheet.Header title="제스처 비활성화" />
+        <BottomSheet.Body className="pt-2 pb-24">
+          이 바텀시트는 스와이프로 닫을 수 없습니다.
+          <br /> 버튼을 눌러 닫아주세요.
+        </BottomSheet.Body>
+        <BottomSheet.Footer>
+          <ExampleCloseButton />
+        </BottomSheet.Footer>
+      </BottomSheet.Content>
+    </BottomSheet>
+  ),
+};

--- a/packages/core/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -42,10 +42,15 @@ const meta: Meta<typeof BottomSheet> = {
       action: 'onOpenChange',
       description: '시트가 열리거나 닫힐 때 호출되는 콜백입니다.',
     },
+    dismissible: {
+      control: 'boolean',
+      description: '스와이프 제스처로 시트를 닫을 수 있는지 여부입니다.',
+    },
   },
   args: {
     headerAlign: 'left',
     defaultOpen: false,
+    dismissible: true,
   },
 };
 

--- a/packages/core/src/components/BottomSheet/BottomSheet.tsx
+++ b/packages/core/src/components/BottomSheet/BottomSheet.tsx
@@ -10,6 +10,7 @@ interface BottomSheetRootProps {
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   headerAlign?: HeaderAlign;
+  dismissible?: boolean;
 }
 
 const BottomSheetRoot = ({
@@ -18,6 +19,7 @@ const BottomSheetRoot = ({
   defaultOpen = false,
   onOpenChange,
   headerAlign = 'left',
+  dismissible = true,
 }: BottomSheetRootProps) => {
   const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
 
@@ -40,7 +42,11 @@ const BottomSheetRoot = ({
         onClose: () => handleOpenChange(false),
       }}
     >
-      <Drawer.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Drawer.Root
+        open={isOpen}
+        onOpenChange={handleOpenChange}
+        dismissible={dismissible}
+      >
         {children}
       </Drawer.Root>
     </BottomSheetContext.Provider>


### PR DESCRIPTION
# 🚀 Pull Request

## Issue

- Closes #156 

## ✨ Summary

BottomSheet에 스와이프 제스처 기능을 비활성화하는 옵션을 추가했습니다.

## 📚 Details of Changes

- [x] BottomSheet 스와이프/드래그 제스처 비활성화 prop (`dismissible`) 추가 
- 기본 값은 `true`
- `false`로 지정할 경우 제스처가 비활성화 됨

## 🎯 Key points to review

- 

## 🧪 Test & Verification
- [x] Storybook UI 확인
- [x] Storybook test (pnpm test-storybook) 완료

> 테스트 결과나 캡처가 있다면 첨부해주세요.


## 📎 Additional Notes

-
