### PR TITLE
[FEAT/#160] Tab plain variant 추가 및 CTA 버튼/언더라인 탭 스타일 수정

### DIFF
--- a/.changeset/itchy-masks-fail.md
+++ b/.changeset/itchy-masks-fail.md
@@ -1,0 +1,5 @@
+---
+'@causw/core': patch
+---
+
+Tab에 배경/테투리 없이 텍스트로만 구성된 plain variant를 추가하고, CTAButton 높이를 48px로, underline variant 탭 텍스트를 typo-body-15-semibold로 수정했습니다.

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,12 +1,12 @@
 addReviewers: true
 addAssignees: false
 reviewers:
-  - kyh0726
-  - yugenius0213
   - gomx3
   - Head-ddy
-  - iris-starry
   - MlNTYS
+  - clue31415
+  - fresh-woo
+  - plamingo509
 numberOfReviewers: 2
 useReviewGroups: false
 skipKeywords:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-
-      - name: Install pnpm
-        run: npm i -g pnpm@latest
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: npm install -g pnpm@latest; pnpm i; npm install -g npm@latest
+        run: pnpm install --frozen-lockfile
 
       - name: Build packages
         run: pnpm build

--- a/packages/core/src/components/CTAButton/CTAButton.styles.ts
+++ b/packages/core/src/components/CTAButton/CTAButton.styles.ts
@@ -1,7 +1,7 @@
 import { tv, type VariantProps } from 'tailwind-variants';
 
 export const ctaButton = tv({
-  base: 'inline-flex items-center justify-center h-[3.375rem] px-[0.5rem] py-[0.875rem] rounded-[0.75rem] typo-body-15-semibold whitespace-nowrap select-none transition-colors cursor-pointer',
+  base: 'inline-flex items-center justify-center h-12 px-2 py-3.5 rounded-[0.75rem] typo-body-15-semibold whitespace-nowrap select-none transition-colors cursor-pointer',
   variants: {
     color: {
       blue: 'bg-blue-100 text-blue-700 enabled:hover:bg-blue-200 enabled:active:bg-blue-200 enabled:data-[active]:bg-blue-200',

--- a/packages/core/src/components/Tab/Tab.stories.tsx
+++ b/packages/core/src/components/Tab/Tab.stories.tsx
@@ -121,6 +121,45 @@ export const Chip: Story = {
   },
 };
 
+export const Plain: Story = {
+  render: () => {
+    const OPTIONS = [
+      { value: 'alumni-contacts', label: '동문수첩' },
+      { value: 'community', label: '소통' },
+    ] as const;
+
+    type TabValue = (typeof OPTIONS)[number]['value'];
+
+    const [value, setValue] = React.useState<TabValue>('alumni-contacts');
+
+    return (
+      <div>
+        <Tab.Root
+          variant="plain"
+          value={value}
+          onValueChange={(val) =>
+            setValue(val as 'alumni-contacts' | 'community')
+          }
+        >
+          <Tab.List className="px-1 py-2">
+            {OPTIONS.map((opt) => (
+              <Tab.TabItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </Tab.TabItem>
+            ))}
+          </Tab.List>
+
+          <Tab.Content value={value}>
+            <ContentBox>
+              <Text>{`선택된 탭: ${value}`}</Text>
+            </ContentBox>
+          </Tab.Content>
+        </Tab.Root>
+      </div>
+    );
+  },
+};
+
 export const CombinedTabs: Story = {
   render: () => {
     const [main, setMain] = React.useState<'all' | 'my'>('all');

--- a/packages/core/src/components/Tab/Tab.styles.ts
+++ b/packages/core/src/components/Tab/Tab.styles.ts
@@ -10,7 +10,7 @@ export const tabs = tv({
       underline: {
         list: 'border-b border-gray-200',
         item: [
-          'flex-1 min-w-fit px-3 py-3 text-center border-b-2 typo-subtitle-16-bold',
+          'flex-1 min-w-fit p-2 text-center border-b-2 typo-body-15-semibold',
           'hover:border-gray-500 hover:text-gray-500',
           'aria-selected:border-gray-700 aria-selected:text-gray-700',
           'aria-[selected=false]:border-transparent aria-[selected=false]:text-gray-300',
@@ -24,6 +24,15 @@ export const tabs = tv({
           'aria-selected:bg-gray-700 aria-selected:text-white',
           'aria-[selected=false]:bg-white aria-[selected=false]:text-gray-600',
           'aria-[selected=false]:hover:bg-gray-200 aria-[selected=false]:active:bg-gray-200',
+        ].join(' '),
+      },
+      plain: {
+        list: 'gap-3',
+        item: [
+          'typo-subtitle-20-bold',
+          'aria-selected:text-gray-700',
+          'aria-[selected=false]:text-gray-300',
+          'aria-[selected=false]:hover:text-gray-400 aria-[selected=false]:active:text-gray-400',
         ].join(' '),
       },
     },


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
- Closes #160

## ✨ Summary
- Tab에 텍스트만 있는 `plain` variant를 추가하고, CTA 버튼 높이와 underline 탭 텍스트 스타일을 조정했습니다.

## 📚 Details of Changes
- `Tab`에 `plain` variant 추가: 테두리·배경 없이 텍스트만, 활성 탭은 `gray-700`/비활성 탭은 `gray-300`으로 색상만 구분
- `CTAButton` 높이를 54px(`h-[3.375rem]`)에서 48px(`h-12`)로 수정
- `underline` variant 탭 아이템 텍스트를 `typo-subtitle-16-bold`에서 `typo-body-15-semibold`로 변경
- `@causw/core` patch changeset 추가
- (별개 변경) `.github/auto_assign.yml` 리뷰어 목록 갱신

## 🎯 Key points to review
- `plain` variant의 색상·타이포그래피가 의도한 디자인과 맞는지
- `underline` 탭 텍스트 크기 축소가 기존 화면에서 레이아웃 깨짐 없는지

## 🧪 Test & Verification
- [x] Storybook UI 확인
- [x] Storybook test (pnpm test-storybook) 완료

<img width="1680" height="972" alt="image" src="https://github.com/user-attachments/assets/edba7b6f-9760-4123-a1a8-3145e13bf6b2" />

<img width="1692" height="672" alt="image" src="https://github.com/user-attachments/assets/b5daea87-6e7c-4a72-9dad-d56ba1600a71" />

## 📎 Additional Notes
- CAUSW-frontend-v3 "동문수첩 개편 1차 스프린트"(CAUCSE/CAUSW-frontend-v3#339)에서 사용 예정
