### PR TITLE
[HOTFIX] 릴리즈 워크플로우 Node 버전 20 -> 24 업그레이드

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
# 🚀 Pull Request

## Issue
- 관련: npm 릴리즈 워크플로우(release.yml) 실패 대응

## ✨ Summary
- 릴리즈 워크플로우의 Node.js 버전을 20에서 24로 올렸습니다.

## 📚 Details of Changes
- `release.yml`의 `actions/setup-node` `node-version`을 `20` → `24`로 변경
- npm trusted publishing(OIDC) handshake가 오래된 npm CLI(Node 20 번들)에서 지원되지 않아 배포가 404로 실패하던 문제 대응

## 🎯 Key points to review
- 머지 후 release.yml이 다시 자동 실행되어 `@causw/core@0.0.30`, `@causw/design-system@0.0.34` 배포를 재시도합니다. npmjs.com Trusted Publisher 설정이 되어 있지 않다면 여전히 실패할 수 있습니다.

## 🧪 Test & Verification
- [ ] Storybook UI 확인 — 워크플로우 설정 변경으로 해당 없음
- [ ] Storybook test (pnpm test-storybook) — 해당 없음
